### PR TITLE
Added animism to two Sami provinces

### DIFF
--- a/simple_mp_mod/events/Norse.txt
+++ b/simple_mp_mod/events/Norse.txt
@@ -1,0 +1,668 @@
+##############################
+# Norse Flavor Events
+#
+# written by Ogulcan Yildirim
+##############################
+namespace = norse_events
+country_event = {
+	id = norse_events.1
+	title = norse_events.1.t
+	desc = norse_events.1.desc
+	picture = NORSE_TEMPLE_eventPicture
+	is_triggered_only = yes
+	# Odin
+	option = {
+		name = norse_events.1.a
+		trigger = {
+			NOT = {
+				has_personal_deity = odin
+			}
+		}
+		change_personal_deity = odin
+	}
+	# Freya
+	option = {
+		name = norse_events.1.b
+		trigger = {
+			NOT = {
+				has_personal_deity = freya
+			}
+		}
+		change_personal_deity = freya
+	}
+	# Tor
+	option = {
+		name = norse_events.1.c
+		trigger = {
+			NOT = {
+				has_personal_deity = tor
+			}
+		}
+		change_personal_deity = tor
+	}
+	# Tyr
+	option = {
+		name = norse_events.1.d
+		trigger = {
+			NOT = {
+				has_personal_deity = tyr
+			}
+		}
+		change_personal_deity = tyr
+	}
+	# Njord
+	option = {
+		name = norse_events.1.e
+		trigger = {
+			NOT = {
+				has_personal_deity = njord
+			}
+		}
+		change_personal_deity = njord
+	}
+	# Snotra
+	option = {
+		name = norse_events.1.f
+		trigger = {
+			NOT = {
+				has_personal_deity = snotra
+			}
+		}
+		change_personal_deity = snotra
+	}
+}
+
+#A wave of Norse nostalgia
+country_event = {
+	id = norse_events.2
+	title = norse_events.2.t
+	desc = norse_events.2.desc
+	picture = RUNESTONE_eventPicture
+	trigger = {
+		has_dlc = "Lions of the North"
+		current_age = age_of_discovery
+		OR = {
+			primary_culture = swedish
+			primary_culture = danish
+			primary_culture = norwegian
+			primary_culture = icelandic
+			primary_culture = norse
+		}
+		NOT = {
+			has_country_flag = had_norse_nostalgia
+		}
+		religion = catholic
+		OR = {
+			is_excommunicated = yes
+			has_country_modifier = the_statue_in_restraint_of_appeals
+		}
+		OR = {
+			ruler_has_personality = scholar_personality
+			ruler_has_personality = sinner_personality
+			AND = {
+				adm = 5
+				dip = 5
+				mil = 5
+			}
+		}
+		owns = 4
+		is_subject = no
+	}
+	mean_time_to_happen = {
+		years = 100
+		#Being excommunicated DESPITE being very religious should make you question the Pope even more
+		modifier = {
+			is_excommunicated = yes
+			has_idea_group = religious_ideas
+			factor = 0.5
+		}
+	}
+	immediate = {
+		hidden_effect = {
+			set_country_flag = had_norse_nostalgia
+		}
+	}
+	option = {
+		#The time as a Christian is really tiresome with popes like these
+		name = norse_events.2.a
+		custom_tooltip = norse_events.2.a.tt		#Ruler will flee into the wilderness to rethink his life decisions
+		add_ruler_modifier = {
+			name = rethinking_catholic_life
+			duration = 10950
+		}
+		add_reform_desire = 0.01
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 0
+		}
+	}
+	option = {
+		#What am I thinking??
+		name = norse_events.2.b
+		add_papal_influence = 10
+		add_reform_desire = -0.01
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 100
+		}
+	}
+}
+
+#A wave of Norse nostalgia - Contact with the Old Gods
+country_event = {
+	id = norse_events.3
+	title = norse_events.3.t
+	desc = norse_events.3.desc
+	picture = FORESTS_eventPicture
+	trigger = {
+		has_dlc = "Lions of the North"
+		OR = {
+			primary_culture = swedish
+			primary_culture = danish
+			primary_culture = norwegian
+			primary_culture = icelandic
+			primary_culture = norse
+		}
+		has_ruler_modifier = rethinking_catholic_life
+		NOT = {
+			has_country_flag = had_norse_discovery_event
+		}
+	}
+	mean_time_to_happen = {
+		months = 60
+		#Owning Bergslagen should shorten it substantially
+		modifier = {
+			owns = 4
+			factor = 0.5
+		}
+		#Being excommunicated DESPITE being very religious should make you question the Pope even more
+		modifier = {
+			is_excommunicated = yes
+			has_idea_group = religious_ideas
+			factor = 0.5
+		}
+	}
+	immediate = {
+		hidden_effect = {
+			set_country_flag = had_norse_discovery_event
+		}
+	}
+	option = {
+		#The time as a Christian is really tiresome with popes like these
+		name = norse_events.3.a
+		set_ruler_religion = norse_pagan_reformed
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 0
+		}
+	}
+	option = {
+		#What am I thinking??
+		name = norse_events.2.b
+		add_papal_influence = 10
+		remove_country_modifier = rethinking_catholic_life
+		add_reform_desire = -0.01
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 100
+		}
+	}
+}
+
+#A wave of Norse nostalgia - The conversion of [Province.GetName]
+country_event = {
+	id = norse_events.4
+	title = norse_events.4.t
+	desc = norse_events.4.desc
+	picture = FORESTS_eventPicture
+	trigger = {
+		has_dlc = "Lions of the North"
+		OR = {
+			primary_culture = swedish
+			primary_culture = danish
+			primary_culture = norwegian
+			primary_culture = icelandic
+			primary_culture = norse
+		}
+		ruler_religion = norse_pagan_reformed
+		NOT = {
+			religion = norse_pagan_reformed
+		}
+		has_ruler_modifier = rethinking_catholic_life
+		any_owned_province = {
+			is_capital = no
+			same_continent = capital
+			is_island = no
+		}
+		NOT = {
+			has_country_flag = had_norce_province_conversion_event
+		}
+	}
+	mean_time_to_happen = {
+		months = 50
+		#Owning Bergslagen should shorten it substantially
+		modifier = {
+			owns = 4
+			factor = 0.5
+		}
+		#Being excommunicated DESPITE being very religious should make you question the Pope even more
+		modifier = {
+			is_excommunicated = yes
+			has_idea_group = religious_ideas
+			factor = 0.5
+		}
+	}
+	immediate = {
+		hidden_effect = {
+			set_country_flag = had_norce_province_conversion_event
+			random_owned_province = {
+				limit = {
+					is_capital = no
+					same_continent = capital
+					is_island = no
+				}
+				save_event_target_as = new_norse_province
+			}
+		}
+	}
+	option = {
+		#The time as a Christian is really tiresome with popes like these
+		name = norse_events.4.a
+		goto = new_norse_province
+		event_target:new_norse_province = {
+			change_religion = norse_pagan_reformed
+		}
+		if = {
+			limit = {
+				ruler_has_personality = sinner_personality
+			}
+			remove_ruler_personality = sinner_personality
+			add_ruler_personality = zealot_personality
+		}
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 0
+		}
+	}
+	option = {
+		#What am I thinking??
+		name = norse_events.2.b
+		add_papal_influence = 10
+		remove_country_modifier = rethinking_catholic_life
+		add_reform_desire = -0.01
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 100
+		}
+	}
+}
+
+#A wave of Norse nostalgia - The wave of Norse Nostalgia hits the court
+country_event = {
+	id = norse_events.5
+	title = norse_events.5.t
+	desc = norse_events.5.desc
+	picture = NORSE_TEMPLE_eventPicture
+	trigger = {
+		has_dlc = "Lions of the North"
+		OR = {
+			primary_culture = swedish
+			primary_culture = danish
+			primary_culture = norwegian
+			primary_culture = icelandic
+			primary_culture = norse
+		}
+		ruler_religion = norse_pagan_reformed
+		NOT = {
+			religion = norse_pagan_reformed
+		}
+		has_ruler_modifier = rethinking_catholic_life
+		any_owned_province = {
+			religion = norse_pagan_reformed
+		}
+		NOT = {
+			has_country_flag = had_norse_country_conversion_event
+		}
+	}
+	mean_time_to_happen = {
+		months = 20
+		#Owning Bergslagen should shorten it substantially
+		modifier = {
+			owns = 4
+			factor = 0.5
+		}
+		#Being excommunicated DESPITE being very religious should make you question the Pope even more
+		modifier = {
+			is_excommunicated = yes
+			has_idea_group = religious_ideas
+			factor = 0.5
+		}
+	}
+	immediate = {
+		hidden_effect = {
+			set_country_flag = had_norse_country_conversion_event
+		}
+	}
+	option = {
+		#The time as a Christian is really tiresome with popes like these
+		name = norse_events.5.a
+		goto = capital
+		capital_scope = {
+			change_religion = norse_pagan_reformed
+		}
+		random_owned_province = {
+			limit = {
+				is_capital = no
+				NOT = {
+					religion = norse_pagan_reformed
+				}
+			}
+		}
+		change_religion = norse_pagan_reformed
+		remove_country_modifier = rethinking_catholic_life
+		add_stability = -3
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 0
+		}
+	}
+	option = {
+		#What am I thinking??
+		name = norse_events.2.b
+		add_papal_influence = 10
+		remove_country_modifier = rethinking_catholic_life
+		add_reform_desire = -0.01
+		ai_chance = {
+			#AI should NEVER become Norse under any circumstance
+			factor = 100
+		}
+	}
+}
+
+# Reconstruction of the Temple in Uppsala
+country_event = {
+	id = norse_events.6
+	title = norse_events.6.t
+	desc = norse_events.6.desc
+	picture = NORSE_TEMPLE_eventPicture
+	goto = 1
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			1 = {
+				set_province_flag = has_uppsala_temple_flag
+			}
+		}
+	}
+	option = {
+		name = norse_events.6.a
+		1 = {
+			add_province_triggered_modifier = religious_center
+			add_province_triggered_modifier = temple_of_uppsala_modifier
+			add_building = cathedral
+		}
+		if = {
+			limit = {
+				NOT = {
+					has_country_flag = has_norse_flexible_deities_permanent
+				}
+			}
+			if = {
+				limit = {
+					has_dlc = "Wealth of Nations"
+				}
+				custom_tooltip = unlock_norse_free_deity_decision_tt
+			}
+			hidden_effect = {
+				set_country_flag = has_norse_flexible_deities_permanent
+			}
+		}
+		ai_chance = {
+			factor = 1
+		}
+	}
+}
+
+# Return to the Norse faith in Scandinavia
+country_event = {
+	id = norse_events.7
+	title = norse_events.7.t
+	desc = norse_events.7.desc
+	picture = RUNESTONE_eventPicture
+	fire_only_once = yes
+	goto = new_norse_province
+	trigger = {
+		has_dlc = "Lions of the North"
+		NOT = {
+			religion = norse_pagan_reformed
+		}
+		OR = {
+			primary_culture = swedish
+			primary_culture = danish
+			primary_culture = norwegian
+			primary_culture = icelandic
+			primary_culture = norse
+		}
+		any_owned_province = {
+			region = scandinavia_region
+			has_rebel_faction = animism_rebels
+			religion = animism
+		}
+		NOT = {
+			religion_group = pagan
+		}
+	}
+	mean_time_to_happen = {
+		months = 12
+	}
+	immediate = {
+		hidden_effect = {
+			random_owned_province = {
+				limit = {
+					region = scandinavia_region
+					has_rebel_faction = animism_rebels
+				}
+				save_event_target_as = new_norse_province
+			}
+		}
+	}
+	option = {
+		#Wonder what will happen from that
+		name = norse_events.7.a
+		disband_rebels = animism_rebels
+		event_target:new_norse_province = {
+			change_religion = norse_pagan_reformed
+			spawn_rebels = {
+				type = norse_pagan_reformed_rebels
+				size = 2
+			}
+			spawn_rebels = {
+				type = norse_pagan_reformed_rebels
+				size = 2
+			}
+		}
+		add_stability = -2
+		ai_chance = {
+			factor = 1
+		}
+	}
+	option = {
+		#Let us all become Norse! - Should actually never be active, but just in case that the rebels get their demands enforced while the event is open
+		name = norse_events.7.b
+		trigger = {
+			religion_group = pagan
+		}
+		disband_rebels = animism_rebels
+		event_target:new_norse_province = {
+			change_religion = norse_pagan_reformed
+		}
+		capital_scope = {
+			change_religion = norse_pagan_reformed
+		}
+		change_religion = norse_pagan_reformed
+		ai_chance = {
+			factor = 1
+		}
+	}
+}
+
+# Embracement of the Norse culture
+country_event = {
+	id = norse_events.8
+	title = norse_events.8.t
+	desc = norse_events.8.desc
+	picture = VIKINGS_eventPicture
+	trigger = {
+		has_dlc = "Lions of the North"
+		has_custom_ideas = no
+		is_playing_custom_nation = no
+		religion = norse_pagan_reformed
+		OR = {
+			primary_culture = swedish
+			primary_culture = danish
+			primary_culture = norwegian
+			primary_culture = icelandic
+		}
+		religious_unity = 0.9
+		stability = 2
+		NOT = {
+			has_country_flag = had_norse_culture_event
+		}
+	}
+	mean_time_to_happen = {
+		months = 20
+	}
+	immediate = {
+		hidden_effect = {
+			set_country_flag = had_norse_culture_event
+		}
+	}
+	option = {
+		#It is time to return to our roots
+		name = norse_events.8.a
+		change_primary_culture = norse
+		capital_scope = {
+			change_culture = norse
+			add_base_tax = 1
+			add_base_production = 1
+			add_base_manpower = 1
+		}
+		custom_tooltip = norse_events.8.a.tt
+		hidden_effect = {
+			set_country_flag = accepted_norse_ideas_flag
+			every_owned_province = {
+				limit = {
+					OR = {
+						culture = swedish
+						culture = icelandic
+						culture = danish
+						culture = norwegian
+					}
+				}
+				change_culture = norse
+			}
+			if = {
+				limit = {
+					OR = {
+						ruler_culture = swedish
+						ruler_culture = icelandic
+						ruler_culture = danish
+						ruler_culture = norwegian
+					}
+				}
+				set_ruler_culture = norse
+			}
+			if = {
+				limit = {
+					has_heir = yes
+					OR = {
+						heir_culture = swedish
+						heir_culture = icelandic
+						heir_culture = danish
+						heir_culture = norwegian
+					}
+				}
+				set_heir_culture = norse
+			}
+			if = {
+				limit = {
+					has_consort = yes
+					OR = {
+						consort_culture = swedish
+						consort_culture = icelandic
+						consort_culture = danish
+						consort_culture = norwegian
+					}
+				}
+				set_consort_culture = norse
+			}
+		}
+		if = {
+			limit = {
+				NOT = {
+					has_idea_group = norse_ideas
+				}
+			}
+			country_event = {
+				id = ideagroups.0
+			}			#Swap Ideas
+		}
+		ai_chance = {
+			factor = 1
+		}
+	}
+	option = {
+		#No, we cannot abandon our current traditions
+		name = norse_events.8.b
+		add_stability_or_adm_power = yes
+		ai_chance = {
+			factor = 1
+		}
+	}
+}
+
+# Return of the North Sea Empire
+country_event = {
+	id = norse_events.9
+	title = norse_events.9.t
+	desc = norse_events.9.desc
+	picture = VIKING_KING_eventPicture
+	is_triggered_only = yes
+	option = {
+		#We shall take the mantle of our ancestors!
+		name = norse_events.9.a
+		set_country_flag = renamed_to_north_sea_empire
+		if = {
+			limit = {
+				NOT = {
+					government_rank = 3
+				}
+			}
+			set_government_rank = 3
+		}
+		override_country_name = NORTH_SEA_EMPIRE
+		set_country_flag = renamed_to_north_sea_empire
+		set_country_flag = has_overriden_color_flag
+		change_country_color = {
+			color = {
+				202
+				245
+				251
+			}
+		}
+		add_prestige = 25
+		ai_chance = {
+			factor = 1
+		}
+	}
+	option = {
+		#It is best if we let the past stay buried.
+		name = norse_events.9.b
+		add_adm_power = 50
+		add_dip_power = 50
+		add_mil_power = 50
+		ai_chance = {
+			factor = 0
+		}
+	}
+}

--- a/simple_mp_mod/history/provinces/315 - Finnmark.txt
+++ b/simple_mp_mod/history/provinces/315 - Finnmark.txt
@@ -1,0 +1,29 @@
+#315 - Finnmark
+
+owner = NOR
+controller = NOR
+add_core = SMI
+culture = sapmi
+religion = animism
+hre = no
+base_tax = 1 
+base_production = 1
+base_manpower = 1
+trade_goods = fish
+capital = "Vard�"
+is_city = yes
+add_core = NOR
+add_local_autonomy = 70
+discovered_by = eastern
+discovered_by = western
+
+
+1450.1.1 = { culture = norwegian }
+1536.1.1 = { religion = protestant owner = DAN controller = DAN add_core = DAN }
+1814.1.14 = {
+	owner = SWE
+	revolt = { type = nationalist_rebels size = 0 }
+	controller = REB
+	remove_core = DAN
+} # Norway is ceded to Sweden following the Treaty of Kiel
+1814.5.17 = { revolt = {} owner = NOR controller = NOR } # Norway declares itself independent and elects Christian Frederik as king

--- a/simple_mp_mod/history/provinces/4151 - Inari.txt
+++ b/simple_mp_mod/history/provinces/4151 - Inari.txt
@@ -1,0 +1,30 @@
+#4151 - Most of Kemi Lappmark: Enare/Inari, Sodankyl�, Kemikyla, Utsjoki, Kittila, Sombio
+
+owner = SWE
+controller = SWE
+add_core = SWE
+add_core = SMI
+culture = sapmi
+religion = animism
+hre = no
+base_tax = 1 
+base_production = 1
+trade_goods = fur
+base_manpower = 1
+add_local_autonomy = 90
+capital = "Sodankyl�" #Uncertain if this existed at that point.
+is_city = yes
+discovered_by = eastern
+discovered_by = western
+
+1527.6.1 = { religion = protestant}
+1598.8.1 = { controller = PLC } # Sigismund tries to reconquer his crown
+1599.7.15 = { controller = SWE } # Duke Karl get it back
+1742.11.5 = { controller = RUS } # The War of the Hats-Estimated date
+1743.8.7 = { controller = SWE } # The Peace of �bo
+1808.9.14 = { controller = RUS } # The Swedish forces are defeated at the battle Oravais
+1809.9.17 = {
+	owner = RUS
+	add_core = RUS
+	remove_core = SWE
+} # Treaty of Fredrikshamn


### PR DESCRIPTION
This PR gives either the Norway or Sweden player a simple way to switch to Norse via provoking animist rebels in one of their Sami provinces.